### PR TITLE
Native Email Verification (Android only)

### DIFF
--- a/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/EmailVerifier.android.kt
+++ b/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/EmailVerifier.android.kt
@@ -1,0 +1,141 @@
+package io.github.jan.supabase.compose.auth.composable
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalContext
+import androidx.credentials.CredentialManager
+import androidx.credentials.DigitalCredential
+import androidx.credentials.ExperimentalDigitalCredentialApi
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetDigitalCredentialOption
+import io.github.jan.supabase.compose.auth.ComposeAuth
+import io.github.jan.supabase.compose.auth.SdJwtParser
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+import org.json.JSONObject
+
+actual class EmailVerifier {
+    private lateinit var activity: Activity
+    private lateinit var scope: CoroutineScope
+    private lateinit var onResult: (Result<VerifiedUserInfo>) -> Unit
+
+    constructor(
+        activity: Activity,
+        scope: CoroutineScope,
+        onResult: (Result<VerifiedUserInfo>) -> Unit
+    ) {
+        this.activity = activity
+        this.scope = scope
+        this.onResult = onResult
+    }
+
+    @OptIn(ExperimentalDigitalCredentialApi::class)
+    actual fun verify(nonce: String?) {
+        scope.launch {
+            try {
+                val credentialManager = CredentialManager.create(activity)
+                val openId4vpRequest = buildOpenId4vpRequest(nonce)
+
+                val getDigitalCredentialOption =
+                    GetDigitalCredentialOption(requestJson = openId4vpRequest)
+                val request = GetCredentialRequest(listOf(getDigitalCredentialOption))
+                val result = credentialManager.getCredential(activity, request)
+                when (val credential = result.credential) {
+                    is DigitalCredential -> {
+                        val responseJsonString = credential.credentialJson
+                        val responseData = JSONObject(responseJsonString)
+                        val vpToken = responseData.getJSONObject("vp_token")
+
+                        val credentialId = vpToken.keys().next()
+                        val rawSdJwt = vpToken.getJSONArray(credentialId).getString(0)
+
+                        val claims = SdJwtParser.parse(rawSdJwt)
+                        val email = claims["email"]?.jsonPrimitive?.content
+                        onResult(
+                            if (email?.isNotEmpty() == true)
+                                Result.failure(Exception("Email claim is missing or empty in SD-JWT response"))
+                            else
+                                Result.success(VerifiedUserInfo(token = rawSdJwt))
+                        )
+                    }
+
+                    else -> {
+                        onResult(Result.failure(Exception("Unexpected credential type returned: ${credential.javaClass.name}")))
+                    }
+                }
+            } catch (e: Exception) {
+                onResult(Result.failure(e))
+            }
+        }
+    }
+
+    private fun buildOpenId4vpRequest(nonce: String?): String {
+        val json = buildJsonObject {
+            putJsonArray("requests") {
+                addJsonObject {
+                    put("protocol", "openid4vp-v1-unsigned")
+                    putJsonObject("data") {
+                        put("response_type", "vp_token")
+                        put("response_mode", "dc_api")
+                        nonce?.let { put("nonce", it) }
+                        putJsonObject("dcql_query") {
+                            putJsonArray("credentials") {
+                                addJsonObject {
+                                    put("id", "user_info_query")
+                                    put("format", "dc+sd-jwt")
+                                    putJsonObject("meta") {
+                                        putJsonArray("vct_values") {
+                                            add("UserInfoCredential")
+                                        }
+                                    }
+                                    putJsonArray("claims") {
+                                        addJsonObject {
+                                            putJsonArray("path") {
+                                                add("email")
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return json.toString()
+    }
+}
+
+@Composable
+actual fun ComposeAuth.rememberEmailVerifier(
+    onResult: (Result<VerifiedUserInfo>) -> Unit
+): EmailVerifier {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val activity = remember(context) {
+        context.findActivity() ?: error("EmailVerifier requires an Activity context")
+    }
+    return remember(activity, scope) {
+        EmailVerifier(activity, scope, onResult)
+    }
+}
+
+private fun Context.findActivity(): Activity? {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is Activity) return context
+        context = context.baseContext
+    }
+    return null
+}

--- a/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/EmailVerifier.android.kt
+++ b/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/EmailVerifier.android.kt
@@ -41,7 +41,7 @@ actual class EmailVerifier {
     }
 
     @OptIn(ExperimentalDigitalCredentialApi::class)
-    actual fun verify(nonce: String?) {
+    actual fun verify(nonce: String) {
         scope.launch {
             try {
                 val credentialManager = CredentialManager.create(activity)
@@ -80,7 +80,7 @@ actual class EmailVerifier {
         }
     }
 
-    private fun buildOpenId4vpRequest(nonce: String?): String {
+    private fun buildOpenId4vpRequest(nonce: String): String {
         val json = buildJsonObject {
             putJsonArray("requests") {
                 addJsonObject {
@@ -88,7 +88,7 @@ actual class EmailVerifier {
                     putJsonObject("data") {
                         put("response_type", "vp_token")
                         put("response_mode", "dc_api")
-                        nonce?.let { put("nonce", it) }
+                        put("nonce", nonce)
                         putJsonObject("dcql_query") {
                             putJsonArray("credentials") {
                                 addJsonObject {

--- a/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/SdJwtParser.kt
+++ b/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/SdJwtParser.kt
@@ -1,0 +1,65 @@
+package io.github.jan.supabase.compose.auth
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+@OptIn(ExperimentalEncodingApi::class)
+internal object SdJwtParser {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun parse(rawSdJwt: String): JsonObject {
+        val claims = mutableMapOf<String, JsonElement>()
+
+        val parts = rawSdJwt.split("~")
+
+        if (parts.isNotEmpty()) {
+            val jwtParts = parts[0].split(".")
+            if (jwtParts.size >= 2) {
+                try {
+                    val payloadDecoded = Base64.UrlSafe.decode(jwtParts[1])
+                    val payloadString = payloadDecoded.toString()
+                    val payloadJson = json.parseToJsonElement(payloadString).jsonObject
+                    for ((key, value) in payloadJson) {
+                        if (key != "_sd" && key != "_sd_alg") {
+                            claims[key] = value
+                        }
+                    }
+                } catch (e: Exception) {
+                    // Ignore payload parsing errors
+                }
+            }
+        }
+
+        for (i in 1 until parts.size) {
+            val part = parts[i].trim()
+            if (part.isEmpty()) continue
+
+            try {
+                val decoded = Base64.UrlSafe.decode(part)
+                val jsonString = decoded.toString()
+
+                if (jsonString.startsWith("[")) {
+                    val array = json.parseToJsonElement(jsonString).jsonArray
+                    if (array.size == 3) {
+                        val key = array[1].jsonPrimitive.contentOrNull.orEmpty()
+                        if (key.isNotEmpty()) {
+                            claims[key] = array[2]
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                // Ignore disclosure parsing errors (e.g. key binding JWT)
+            }
+        }
+
+        return JsonObject(claims)
+    }
+}

--- a/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/EmailVerifier.kt
+++ b/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/EmailVerifier.kt
@@ -1,0 +1,17 @@
+package io.github.jan.supabase.compose.auth.composable
+
+import androidx.compose.runtime.Composable
+import io.github.jan.supabase.compose.auth.ComposeAuth
+
+data class VerifiedUserInfo(
+    val token: String
+)
+
+expect class EmailVerifier {
+    fun verify(nonce: String?)
+}
+
+@Composable
+expect fun ComposeAuth.rememberEmailVerifier(
+    onResult: (Result<VerifiedUserInfo>) -> Unit
+): EmailVerifier

--- a/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/EmailVerifier.kt
+++ b/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/EmailVerifier.kt
@@ -8,7 +8,7 @@ data class VerifiedUserInfo(
 )
 
 expect class EmailVerifier {
-    fun verify(nonce: String?)
+    fun verify(nonce: String)
 }
 
 @Composable

--- a/ComposeAuth/src/nativeMain/kotlin/io/github/jan/supabase/compose/auth/composable/EmailVerifier.native.kt
+++ b/ComposeAuth/src/nativeMain/kotlin/io/github/jan/supabase/compose/auth/composable/EmailVerifier.native.kt
@@ -1,0 +1,11 @@
+package io.github.jan.supabase.compose.auth.composable
+
+@androidx.compose.runtime.Composable
+actual fun io.github.jan.supabase.compose.auth.ComposeAuth.rememberEmailVerifier(onResult: (kotlin.Result<io.github.jan.supabase.compose.auth.composable.VerifiedUserInfo>) -> Unit): io.github.jan.supabase.compose.auth.composable.EmailVerifier {
+    TODO("Not yet implemented")
+}
+
+actual class EmailVerifier {
+    actual fun verify(nonce: String?) {
+    }
+}

--- a/ComposeAuth/src/nativeMain/kotlin/io/github/jan/supabase/compose/auth/composable/EmailVerifier.native.kt
+++ b/ComposeAuth/src/nativeMain/kotlin/io/github/jan/supabase/compose/auth/composable/EmailVerifier.native.kt
@@ -6,6 +6,6 @@ actual fun io.github.jan.supabase.compose.auth.ComposeAuth.rememberEmailVerifier
 }
 
 actual class EmailVerifier {
-    actual fun verify(nonce: String?) {
+    actual fun verify(nonce: String) {
     }
 }

--- a/ComposeAuth/src/noDefaultMain/kotlin/io/github/jan/supabase/compose/auth/composable/EmailVerifier.noDefault.kt
+++ b/ComposeAuth/src/noDefaultMain/kotlin/io/github/jan/supabase/compose/auth/composable/EmailVerifier.noDefault.kt
@@ -1,0 +1,14 @@
+package io.github.jan.supabase.compose.auth.composable
+
+import androidx.compose.runtime.Composable
+import io.github.jan.supabase.compose.auth.ComposeAuth
+
+actual class EmailVerifier {
+    actual fun verify(nonce: String?) {
+    }
+}
+
+@Composable
+actual fun ComposeAuth.rememberEmailVerifier(onResult: (Result<VerifiedUserInfo>) -> Unit): EmailVerifier {
+    TODO("Not yet implemented")
+}

--- a/ComposeAuth/src/noDefaultMain/kotlin/io/github/jan/supabase/compose/auth/composable/EmailVerifier.noDefault.kt
+++ b/ComposeAuth/src/noDefaultMain/kotlin/io/github/jan/supabase/compose/auth/composable/EmailVerifier.noDefault.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import io.github.jan.supabase.compose.auth.ComposeAuth
 
 actual class EmailVerifier {
-    actual fun verify(nonce: String?) {
+    actual fun verify(nonce: String) {
     }
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Introduce Native Email Verification for Android

## What is the current behavior?
User have to verify email from link in their mail box

## What is the new behavior?
Get verified directly from the device and send SD-JWT to Edge Function to update email verification status

## Additional context

### High Level

```mermaid
sequenceDiagram
    participant App as Android App
    participant CM as Credentials Manager
    participant EF as Edge Function
    participant Google as Google Identity Services

    App->>CM: 1. Request Digital Credentials
    CM-->>App: 2. Return Digital Credentials (SD-JWT)

    App->>App: 3. Extract SD-JWT Token

    App->>EF: 4. Send SD-JWT Token

    EF->>Google: 5. Validate Issuer + Signature
    Google-->>EF: Validation Result

    alt Validation Successful
        EF->>EF: 6. Update Email Verification Status
        EF-->>App: Success Response
    else Validation Failed
        EF-->>App: Error Response
    end

    Note over App,Google: High-level Email Verification Flow using Google Digital Credentials

```

### Limitation
Due to current state of Supabase, there is no API can perform email verification directly with SD-JWT with Google. Also no way can exchange OIDC token.
That is why we need to have our own backend or use Edge Function to do this.

### How to set up
The PR contains Android implementation
The code below shows basic validation with `@sd-jwt/sd-jwt-vc`. Includes claims, issuer and signa ture

From the docs:

> The validation on the server must achieve the following:
> 
> Verify issuer: Ensure the iss (issuer) field matches https://verifiablecredentials-pa.googleapis.com.
> Verify signature: Check the signature of the SD-JWT using the public keys (JWKs) available at https://verifiablecredentials-pa.googleapis.com/.well-known/vc-public-jwks.


### Edge Function

Use supabase-kt to trigger function:

```kotlin
functions.invoke("email-verification", body = buildJsonObject {
                put("token", token)
            })
```


```typescript

import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
import { createClient } from "https://esm.sh/@supabase/supabase-js@2"
import { SDJwtVcInstance } from "npm:@sd-jwt/sd-jwt-vc"

const ISSUER = 'https://verifiablecredentials-pa.googleapis.com'
const JWKS_URL = 'https://verifiablecredentials-pa.googleapis.com/.well-known/vc-public-jwks'

// 🛠️ SUPABASE CLIENT SETUP
const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
const supabaseClient = createClient(supabaseUrl, serviceRoleKey);

let jwksCache: any = null
let cacheTime = 0

async function getJwks() {
  const now = Date.now()
  if (jwksCache && now - cacheTime < 3600000) return jwksCache

  console.log("🔄 [JWKS]: Fetching fresh public keys...")
  const res = await fetch(JWKS_URL)
  if (!res.ok) throw new Error(`JWKS fetch failed: ${res.statusText}`)

  jwksCache = await res.json()
  cacheTime = now
  console.log(`✅ [JWKS]: Cached ${jwksCache.keys?.length} keys`)
  return jwksCache
}

function base64urlDecode(input: string): Uint8Array {
  let base64 = input.replace(/-/g, '+').replace(/_/g, '/')
  while (base64.length % 4) base64 += '='
  const binary = atob(base64)
  return Uint8Array.from(binary, c => c.charCodeAt(0))
}

const cryptoDigest = async (data: string | Uint8Array): Promise<Uint8Array> => {
  const binary = typeof data === "string" 
    ? new TextEncoder().encode(data) 
    : new Uint8Array((data as any).buffer || data)
  const hashBuffer = await crypto.subtle.digest("SHA-256", binary)
  return new Uint8Array(hashBuffer)
}

async function verifier(jwt: string): Promise<boolean> {
  console.log("🔐 [Verifier] Verifying:", jwt.substring(0, 100) + "...")
  try {
    const parts = jwt.split('.')
    if (parts.length < 3) return false

    const [headerB64, payloadB64, signatureB64] = parts
    const header = JSON.parse(new TextDecoder().decode(base64urlDecode(headerB64)))

    console.log(`📋 [Verifier] Header: alg=${header.alg}, kid=${header.kid || 'N/A'}`)

    const jwks = await getJwks()
    let matchingKey = jwks.keys.find((k: any) => k.kid === header.kid)
    if (!matchingKey) {
      console.log("⚠️ kid not found → fallback")
      matchingKey = jwks.keys[0]
    }

    let importAlgorithm: any
    let verifyAlgorithm: any
    let jwkToImport: any

    if (header.alg === "EdDSA" || matchingKey.kty === "OKP") {
      importAlgorithm = { name: "Ed25519" }
      verifyAlgorithm = { name: "Ed25519" }
      jwkToImport = {
        kty: "OKP",
        crv: "Ed25519",
        x: matchingKey.x,
      }
    } else {
      importAlgorithm = { name: "ECDSA", namedCurve: matchingKey.crv || "P-256" }
      verifyAlgorithm = { name: "ECDSA", hash: { name: "SHA-256" } }
      jwkToImport = {
        kty: "EC",
        crv: matchingKey.crv || "P-256",
        x: matchingKey.x,
        y: matchingKey.y,
      }
    }

    const publicKey = await crypto.subtle.importKey(
      "jwk", jwkToImport, importAlgorithm, false, ["verify"]
    )

    const isValid = await crypto.subtle.verify(
      verifyAlgorithm,
      publicKey,
      base64urlDecode(signatureB64),
      new TextEncoder().encode(`${headerB64}.${payloadB64}`)
    )

    console.log(`🎯 [Verifier] Signature valid: ${isValid}`)
    return isValid
  } catch (e: any) {
    console.error("💥 [Verifier] Error:", e.message)
    return false
  }
}

serve(async (req) => {
  try {
    const body = await req.json()
    let token = body.token || (body.requests?.[0]?.data?.vp_token)
    const nonce = body.nonce || "gZ9QWztlI09rlZzOdVQjAIJ56LYn-lWHXf5saeusqHc"

    if (!token) {
      return new Response(JSON.stringify({ error: "Missing token" }), { status: 400 })
    }

    // 🛠️ FIX: Clean token to prevent split error caused by trailing tilde (~)
    token = token.trim().replace(/~+$/, '')

    console.log(`🚀 [SD-JWT VC] Starting validation with expected nonce: ${nonce}`)

    const sdjwt = new SDJwtVcInstance({
      verifier,
      hasher: cryptoDigest,
      hashAlg: 'sha-256',
    })
    

    // 🔬 DECODE & EXTRACT CLAIMS
    const decoded = await sdjwt.decode(token)
    const claims = await sdjwt.getClaims(token)

    // 🖨️ PRINT DECODE AND CLAIMS TO LOGS
    console.log("==================================================================")
    console.log("📦 [DECODED SD-JWT]:\n", JSON.stringify(decoded, null, 2))
    console.log("==================================================================")
    console.log("📋 [RESOLVED CLAIMS]:\n", JSON.stringify(claims, null, 2))
    console.log("==================================================================")

    if (claims.iss !== ISSUER) {
      return new Response(JSON.stringify({ error: "Unauthorized issuer" }), { status: 401 })
    }

    if (claims.vct !== "UserInfoCredential") {
      console.log(`⚠️ vct mismatch: ${claims.vct}`)
    }

    // ⚡ SUPABASE ADMIN EMAIL UPDATE LOGIC
    if (!claims.email) {
      return new Response(JSON.stringify({ error: "Missing email claim in token" }), { status: 400 })
    }

    console.log(`⚡ [Supabase Admin]: Finding user with email: ${claims.email}`)
    const { data: { users }, error } = await supabaseClient.auth.admin.listUsers()
    
    if (error) {
      throw new Error(`Failed to list users: ${error.message}`)
    }
    const targetedUser = users.find(u => u.email === claims.email)

    if (!targetedUser) {
      return new Response(JSON.stringify({ 
        error: `No account found matching verified email address: ${claims.email}` 
      }), { status: 404 })
    }

    console.log(`⚡ [Supabase Admin]: Updating email verification status for UID: ${targetedUser.id}`)
    const { data: user, error: updateError } = await supabaseClient.auth.admin.updateUserById(
      targetedUser.id,
      { email_confirm: true }
    )

    if (updateError) {
      throw new Error(`Failed to confirm email via Admin API: ${updateError.message}`)
    }

    console.log(`🎉 Success! Email verification state confirmed for UID: ${user.user.id}`)
    return new Response(JSON.stringify({
      status: "Success! Email verification state confirmed for UID",
    }), { 
      status: 200,
      headers: { "Content-Type": "application/json" }
    })

  } catch (error: any) {
    console.error("💥 Validation Error:", error.message)
    return new Response(JSON.stringify({ 
      error: `Validation Error: ${error.message}` 
    }), { 
      status: 401,
      headers: { "Content-Type": "application/json" }
    })
  }
})
```

### Reference
https://developer.android.com/identity/digital-credentials/email-verification-implementation
https://www.npmjs.com/package/@sd-jwt/sd-jwt-vc


