### PR TITLE
fix: catch onIdToken exceptions in the iOS Google flow

### DIFF
--- a/ComposeAuth/src/appleMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
+++ b/ComposeAuth/src/appleMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
@@ -11,6 +11,7 @@ import io.github.jan.supabase.compose.auth.hash
 import io.github.jan.supabase.logging.d
 import io.github.jan.supabase.logging.e
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import nativeBridge.GoogleSignInController
@@ -57,16 +58,22 @@ actual fun ComposeAuth.rememberSignInWithGoogle(
                                     onResult.invoke(NativeSignInResult.ClosedByUser)
                                 } else if (idToken != null) {
                                     logger.d { "Id token available" }
-                                    onIdToken.invoke(
-                                        composeAuth = this@rememberSignInWithGoogle,
-                                        result = IdTokenCallback.Result(
-                                            idToken = idToken,
-                                            provider = Google,
-                                            nonce = startedStatus.nonce,
-                                            extraData = startedStatus.extraData
+                                    try {
+                                        onIdToken.invoke(
+                                            composeAuth = this@rememberSignInWithGoogle,
+                                            result = IdTokenCallback.Result(
+                                                idToken = idToken,
+                                                provider = Google,
+                                                nonce = startedStatus.nonce,
+                                                extraData = startedStatus.extraData
+                                            )
                                         )
-                                    )
-                                    onResult.invoke(NativeSignInResult.Success(SignInResultData.Google()))
+                                        onResult.invoke(NativeSignInResult.Success(SignInResultData.Google()))
+                                    } catch (e: Exception) {
+                                        currentCoroutineContext().ensureActive()
+                                        logger.e(e) { "Error while logging into Supabase with Google ID Token Credential" }
+                                        onResult.invoke(NativeSignInResult.Error(e.message ?: "error", e))
+                                    }
                                 } else if (errorMessage != null) {
                                     logger.d { "Error happens due to: $errorMessage" }
                                     onResult.invoke(NativeSignInResult.Error(errorMessage))


### PR DESCRIPTION
The completion handler passed to GogleSignInController.signInCompletion runs after signInCompletion has already returned, so the try/catch around it in rememberSignInWithGoogle never covered the handler body. Any exception from onIdToken escaped the scope.launch uncaught and aborted the process with SIGABRT.

This is easy to hit with ComposeAuth.LINK_IDENTITY_CALLBACK, where a server-side rejection is a normal outcome: linking a Google identity that already belongs to another user returns identity_already_exists and the app died instead of reporting the failure.

Wrap onIdToken/onResult in a try/catch inside scope.launch, mirroring AuthorizationDelegate in AppleAuth.kt, and report NativeSignInResult.Error with the exception attached. CancellationException is rethrown via ensureActive() so a cancelled scope is not surfaced as a sign-in error, matching the Android flow.

The Android flow already catches around onIdToken within the same coroutine and is unaffected.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The app crashes instead of handling the error

## What is the new behavior?

The library handles the error the same way it already handles Apple sign in errors